### PR TITLE
Change grep --ignore-case to -i for busybox compatibility

### DIFF
--- a/usr/sbin/snmpd-mdraid-connector
+++ b/usr/sbin/snmpd-mdraid-connector
@@ -50,7 +50,7 @@ function get_field
 
 	# Try to find the search string and get its line into an array.
 	# shellcheck disable=SC2207
-	VALUES=($(grep --ignore-case "${2}" < "${DFNAME}"))
+	VALUES=($(grep -i "${2}" < "${DFNAME}"))
 	
 	# Loop through the results looking for a ":", the value we want is next.
 	for (( L=0; L<${#VALUES[@]}; L++ ))
@@ -79,7 +79,7 @@ function get_line
 
 	# Try to find the search string and get its line
     # shellcheck disable=SC2207
-	VALUE=$(grep --ignore-case "${2}[[:space:]]*:" < "${DFNAME}" | head -1)
+	VALUE=$(grep -i "${2}[[:space:]]*:" < "${DFNAME}" | head -1)
 
 	if [[ $VALUE =~ ${2}[[:space:]]*:[[:space:]]*(.*) ]]; then
 		eval "$3"=\""${BASH_REMATCH[1]}"\"


### PR DESCRIPTION
Change grep --ignore-case to -i for busybox compatibility.
ESOS SAN linux uses busybox.
